### PR TITLE
feat: add muti strategy backtest

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@ch20026103/anysis": "0.0.17-alpha1",
-    "@ch20026103/backtest-lib": "0.0.3-alpha",
+    "@ch20026103/backtest-lib": "0.0.3-alpha1",
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.0",
     "@mui/icons-material": "^6.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ dependencies:
     specifier: 0.0.17-alpha1
     version: 0.0.17-alpha1
   '@ch20026103/backtest-lib':
-    specifier: 0.0.3-alpha
-    version: 0.0.3-alpha
+    specifier: 0.0.3-alpha1
+    version: 0.0.3-alpha1
   '@emotion/react':
     specifier: ^11.14.0
     version: 11.14.0(@types/react@18.3.21)(react@18.3.1)
@@ -318,8 +318,8 @@ packages:
     resolution: {integrity: sha512-iYSYGuRu3P9DugXrFvo1upEUxOBZ9s3upIY0Q/Wd1yyT4VNFfMWlLbWrMUSmL5AjZgc1zHJQnECwu+sMxNJafQ==}
     dev: false
 
-  /@ch20026103/backtest-lib@0.0.3-alpha:
-    resolution: {integrity: sha512-zCt3PnV+Hgzikuz0MOKlwpqnV4yW6zzld91umSC87DrMf2Pt2XYtQJxgQxzMr8drS+nFUS6Qq1bQkxym+A73Rg==}
+  /@ch20026103/backtest-lib@0.0.3-alpha1:
+    resolution: {integrity: sha512-bJQaGpPzpJ8v/CI473sul8AGgVNW6a7jhDxCxW3SWMtUVMM1n6lLXRMTS7giYXQUjgS9hmPKEzodNEQL+kHp9w==}
     dependencies:
       '@ch20026103/anysis': 0.0.17-alpha1
       '@types/node': 22.15.18

--- a/src/pages/Schoice/Backtest/options.tsx
+++ b/src/pages/Schoice/Backtest/options.tsx
@@ -30,7 +30,7 @@ export default function Options({
   const handleChange =
     (key: keyof BacktestOptions) =>
     (event: React.ChangeEvent<HTMLInputElement>) => {
-      setOptions((prev) => ({
+      setOptions((prev: BacktestOptions) => ({
         ...prev,
         [key]: parseFloat(event.target.value),
       }));
@@ -38,7 +38,7 @@ export default function Options({
 
   const handleSelectChange =
     (key: keyof BacktestOptions) => (event: SelectChangeEvent<unknown>) => {
-      setOptions((prev) => ({
+      setOptions((prev: BacktestOptions) => ({
         ...prev,
         [key]: event.target.value as BuyPrice | SellPrice,
       }));
@@ -66,7 +66,7 @@ export default function Options({
         onChange={handleChange("hightStockPrice")}
       />
       <TextField
-        label="可承受虧損"
+        label="可承受虧損(%)"
         size="small"
         type="number"
         onChange={handleChange("hightLoss")}

--- a/src/pages/Schoice/Backtest/useBacktestFunc.tsx
+++ b/src/pages/Schoice/Backtest/useBacktestFunc.tsx
@@ -75,7 +75,7 @@ export default function useBacktestFunc() {
     async (
       stockId: string,
       date: number,
-      inWait: boolean,
+      inWait: boolean | undefined,
       { select, type }: { select: PromptItem; type: BacktestType }
     ): Promise<StockType | null> => {
       try {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enabled multi-selection for "Bull Strategy" and "Bears Strategy" dropdowns in the backtest interface, allowing users to select and apply multiple strategies simultaneously.

- **Improvements**
  - Enhanced tooltips and display for strategy selection, including clearer multi-selection support.
  - Updated a label for better clarity in the options panel.

- **Bug Fixes**
  - Improved type safety in options handling and function parameters for more robust behavior.

- **Chores**
  - Updated a library dependency to a newer pre-release version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->